### PR TITLE
Little improvement

### DIFF
--- a/application/libraries/Plugins.php
+++ b/application/libraries/Plugins.php
@@ -24,21 +24,33 @@ class Plugins {
     public static $errors;
     public static $messages;
     
-    public function __construct()
+    public function __construct($params = array())
     {
         $this->_ci      = get_instance(); // Codeigniter instance
         self::$instance = $this;          // Instance of this class
         
-        $this->_ci->load->driver('cache', array('adapter' => 'apc', 'backup' => 'file'));
+        // Driver library only available on CI 2.0+
+        if (CI_VERSION >= 2.0)
+        {
+        	$this->_ci->load->driver('cache', array('adapter' => 'apc', 'backup' => 'file'));
+        }
+        $this->_ci->load->database();
         $this->_ci->load->helper('directory');
         $this->_ci->load->helper('file');
         
-        // Set the plugins directory if not already set
-        if ( is_null($this->plugins_dir) )
+        // Set the plugins directory if passed via paramater
+        if (array_key_exists('plugins_dir', $params))
         {
-            $this->plugins_dir = FCPATH . "plugins/";   
-        }  
+        	$this->set_plugin_dir($params['plugins_dir']);
+        }
+        else // else set to default value
+        {
+        	$this->set_plugin_dir(FCPATH . "plugins/");
+        }
         
+        // Remove index.php string on the plugins directory if any
+        $this->plugins_dir = str_replace("index.php", "", $this->plugins_dir);      
+                
         $this->find_plugins();          // Find all plugins
         $this->get_activated_plugins(); // Get all activated plugins
         $this->get_plugin_infos();      // Gets information about all plugins and stores it
@@ -53,7 +65,7 @@ class Plugins {
     * 
     * @param mixed $directory
     */
-    public function set_plugin_dir($directory)
+    private function set_plugin_dir($directory)
     {
         if ( !empty($directory) )
         {


### PR DESCRIPTION
Hi
I've made little improvement to your plugin library.

FYI, i'm using CI 1.7.2, although you already mention it for 2.0+, but it will be nice if we can provide backward compatibility too :)

So, my changes would be:
-    **Remove index.php string on plugins_dir if any**
  For some reason (in my CI version) FCPATH include unwanted index.php string, so the path will be incorrect. So the best option is remove the index.php string if any.
-    **Allow to set plugins_dir via params**
  At current code, you provide set_plugin_dir() function, but actually it's useless because on the constructor, you execute find_plugins() and 3 other function that require plugins_dir value to be set before the function run. So the best option is allow user to provide plugins_dir when the library loaded. Now, user can do this:
  <code>$this->load->library('plugins', array('plugins_dir' => $my_path));</code>
  Or user can put the plugins_dir on config file if decide to autoload the library.
-    **Only load driver library if CI_VERSION >= 2.0**
  I see you use cache driver but looks like it's currently unused, maybe in the future?. However, this will be problem because CI_VERSION < 2.0 doesn't have the driver library. So the best option is to enabled it only for CI_VERSION >= 2.0.
-    **Load database library**
  This library use database class, however you assume that the database class autoloaded. But not all people do, so the best option is to load the database manually.

That's it :)
